### PR TITLE
Set default icon to mdi:emoticon-excited-outline

### DIFF
--- a/custom_components/jokes/sensor.py
+++ b/custom_components/jokes/sensor.py
@@ -14,6 +14,8 @@ async def async_setup_platform(
 class JokeEntity(CoordinatorEntity):
     """Dummy entity to trigger updates."""
 
+    _attr_icon = "mdi:emoticon-excited-outline"
+
     def __init__(self, coordinator: DataUpdateCoordinator):
         """Pass coordinator to CoordinatorEntity."""
         super().__init__(coordinator)


### PR DESCRIPTION
Set the icon to something else than the default eye. 
I ended up with mdi:emoticon-excited-outline. 

Now stands out a bit more in places like the logbook
![image](https://user-images.githubusercontent.com/732514/209958224-e8bb612e-5722-46e8-aae4-824e1966c54c.png)

