### PR TITLE
Add useragent

### DIFF
--- a/custom_components/jokes/__init__.py
+++ b/custom_components/jokes/__init__.py
@@ -70,7 +70,10 @@ class JokeUpdateCoordinator(DataUpdateCoordinator):
         
         #get a random joke (finally)
         try:
-            headers = {'Accept': 'application/json'}
+            headers = {
+                'Accept': 'application/json',
+                'User-Agent': 'Jokes custom integration for Home Assistant (https://github.com/LaggAt/ha-jokes)'
+            }
             async with aiohttp.ClientSession() as session:
                 async with session.get('https://icanhazdadjoke.com/', headers=headers) as resp:
                     if resp.status == 200:


### PR DESCRIPTION
I was looking at the icanhazdadjoke API and noticed the following text below

> from https://icanhazdadjoke.com/api
>If you intend on using the icanhazdadjoke.com API we kindly ask that you set a custom User-Agent header for all requests.
>
>Setting a custom User-Agent header for your code will help us be able to better monitor the usage of the API and identify potential bad actors.
>
>A good user agent should include the name of the library or website that is accessing the API along with a URL/e-email where someone can be contacted regarding the library/website.
>
>For example: curl -H "User-Agent: My Library (https://github.com/username/repo)" https://icanhazdadjoke.com/

I noticed no custom useragent was used so I added it